### PR TITLE
simplify NodeGetVolumeStats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 .PHONY: all disk
 
 DISK_IMAGE_NAME=csiplugin/csi-qingcloud
-DISK_VERSION=v1.2.0-rc.3
+DISK_VERSION=v1.2.0-rc.4
 ROOT_PATH=$(pwd)
 PACKAGE_LIST=./cmd/... ./pkg/...
 

--- a/pkg/disk/rpcserver/nodeserver.go
+++ b/pkg/disk/rpcserver/nodeserver.go
@@ -487,31 +487,7 @@ func (ns *NodeServer) NodeGetVolumeStats(ctx context.Context,
 		return nil, status.Error(codes.InvalidArgument, "Volume path missing in request")
 	}
 
-	volumeId := req.GetVolumeId()
 	volumePath := req.GetVolumePath()
-
-	// Get volume info
-	klog.Infof("%s: Get volume %s info", hash, volumeId)
-	volInfo, err := ns.cloud.FindVolume(volumeId)
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	if volInfo == nil || volInfo.Instance == nil || volInfo.Instance.Device == nil {
-		return nil, status.Errorf(codes.NotFound, "cannot find volume %s", volumeId)
-	}
-
-	// Checkout device
-	klog.Infof("%s: Get device name from mount point %s", hash, volumePath)
-	devicePath, _, err := mount.GetDeviceNameFromMount(ns.mounter, volumePath)
-	if err != nil {
-		return nil, status.Errorf(codes.NotFound, "cannot get device name from mount point %s", volumePath)
-	}
-	klog.Infof("%s: Succeed to get device name %s", hash, devicePath)
-	if devicePath == "" || *volInfo.Instance.Device != devicePath {
-		return nil, status.Errorf(codes.NotFound, "device path mismatch, from mount point %s, "+
-			"from cloud provider %s", devicePath, *volInfo.Instance.Device)
-	}
-
 	// Get metrics
 	metricsStatFs := volume.NewMetricsStatFS(volumePath)
 	metrics, err := metricsStatFs.GetMetrics()


### PR DESCRIPTION
Signed-off-by: zhangmin <arminzhang@yunify.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
 /kind bug


**What this PR does / why we need it**:
If there are hundreds of nodes of k8s, **NodeGetVolumeStats** will be called abount one minitue and half on each node. It's too mnay for the iaas api, and cause qingcloud-csi not work.  So i remove the api call of **NodeGetVolumeStats**, and it has no influence of the qingcloud-csi. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation e.g., usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```