### PR TITLE
Fix the wrong check of whether node expansion is required

### DIFF
--- a/pkg/disk/rpcserver/controllerserver.go
+++ b/pkg/disk/rpcserver/controllerserver.go
@@ -678,7 +678,7 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 	}
 
 	// If volume is in block mode, it doesn't need NodeExpandVolume operation
-	nodeExpansionRequired := req.GetVolumeCapability().GetBlock() != nil
+	nodeExpansionRequired := req.GetVolumeCapability().GetBlock() == nil
 
 	// For idempotent
 	volSizeBytes := common.GibToByte(*volInfo.Size)


### PR DESCRIPTION
Signed-off-by: dkeven <keven@kubesphere.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
https://github.com/yunify/qingcloud-csi/pull/195 adds support for block volume.
In the `ControllerExpandVolume` interface response, node expansion is required only when the volume mode is not block, which means the `req.GetVolumeCapability().GetBlock()` is `nil`. But this check is incorrectly set to the opposite.